### PR TITLE
add scheduler policy without NoVolumeZoneConflict

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -154,7 +154,29 @@ sed -i '
     /^KUBE_CONTROLLER_MANAGER_ARGS=/ s#\(KUBE_CONTROLLER_MANAGER_ARGS\).*#\1="'"${KUBE_CONTROLLER_MANAGER_ARGS}"'"#
 ' /etc/kubernetes/controller-manager
 
-sed -i '/^KUBE_SCHEDULER_ARGS=/ s/=.*/="--leader-elect=true"/' /etc/kubernetes/scheduler
+KUBE_SCHEDULER_POLICY=/etc/kubernetes/scheduler-policy.json
+sed -i "/^KUBE_SCHEDULER_ARGS=/ s/=.*/='--leader-elect=true --policy-config-file=${KUBE_SCHEDULER_POLICY}'/" /etc/kubernetes/scheduler
+
+cat << EOF >> ${KUBE_SCHEDULER_POLICY}
+{
+"kind" : "Policy",
+"apiVersion" : "v1",
+"predicates" : [
+    {"name" : "PodFitsHostPorts"},
+    {"name" : "PodFitsResources"},
+    {"name" : "NoDiskConflict"},
+    {"name" : "MatchNodeSelector"},
+    {"name" : "HostName"}
+    ],
+"priorities" : [
+    {"name" : "LeastRequestedPriority", "weight" : 1},
+    {"name" : "BalancedResourceAllocation", "weight" : 1},
+    {"name" : "ServiceSpreadingPriority", "weight" : 1},
+    {"name" : "EqualPriority", "weight" : 1}
+    ],
+"hardPodAffinitySymmetricWeight" : 10
+}
+EOF
 
 mkdir -p /etc/kubernetes/manifests
 HOSTNAME_OVERRIDE=$(hostname --short | sed 's/\.novalocal//')

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -155,7 +155,7 @@ sed -i '
 ' /etc/kubernetes/controller-manager
 
 KUBE_SCHEDULER_POLICY=/etc/kubernetes/scheduler-policy.json
-sed -i "/^KUBE_SCHEDULER_ARGS=/ s/=.*/='--leader-elect=true --policy-config-file=${KUBE_SCHEDULER_POLICY}'/" /etc/kubernetes/scheduler
+sed -i '/^KUBE_SCHEDULER_ARGS=/ s/=.*/="--leader-elect=true --policy-config-file=\/etc\/kubernetes\/scheduler"/' /etc/kubernetes/scheduler
 
 cat << EOF >> ${KUBE_SCHEDULER_POLICY}
 {

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -155,7 +155,7 @@ sed -i '
 ' /etc/kubernetes/controller-manager
 
 KUBE_SCHEDULER_POLICY=/etc/kubernetes/scheduler-policy.json
-sed -i '/^KUBE_SCHEDULER_ARGS=/ s/=.*/="--leader-elect=true --policy-config-file=\/etc\/kubernetes\/scheduler"/' /etc/kubernetes/scheduler
+sed -i '/^KUBE_SCHEDULER_ARGS=/ s/=.*/="--leader-elect=true --policy-config-file=\/etc\/kubernetes\/scheduler-policy.json"/' /etc/kubernetes/scheduler
 
 cat << EOF >> ${KUBE_SCHEDULER_POLICY}
 {


### PR DESCRIPTION
The default scheduler policy has `NoVolumeZoneConflict` which prevents Kubernetes from mounting volumes with different availability zones than servers.